### PR TITLE
Add mappings for Thermopro TP12

### DIFF
--- a/rtl433json_to_influx.py
+++ b/rtl433json_to_influx.py
@@ -12,7 +12,7 @@ mappings = {
         'temperature': None,
         'temperature_C': None,
         'temperature_C1': None,
-        'temperature_C1': None,
+        'temperature_C2': None,
         'temperature_2_C': None,
         'temperature_1_C': None,
         'temperature_F': None,

--- a/rtl433json_to_influx.py
+++ b/rtl433json_to_influx.py
@@ -12,7 +12,9 @@ mappings = {
         'temperature': None,
         'temperature_C': None,
         'temperature_C1': None,
-        'temperature_C2': None,
+        'temperature_C1': None,
+        'temperature_2_C': None,
+        'temperature_1_C': None,
         'temperature_F': None,
         'ptemperature_C': None,
 


### PR DESCRIPTION
The latest version of rtl433 emits mappings for the TP12 Thermometer that aren't in the mappings list, causing the data to be silently skipped :)

This PR adds them.

```{"time" : "2019-03-25 23:24:59", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}
{"time" : "2019-03-25 23:25:11", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}
{"time" : "2019-03-25 23:25:11", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}
{"time" : "2019-03-25 23:25:11", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}
{"time" : "2019-03-25 23:25:23", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}
{"time" : "2019-03-25 23:25:23", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}
{"time" : "2019-03-25 23:25:23", "model" : "Thermopro TP12 Thermometer", "id" : 209, "temperature_1_C" : 320.000, "temperature_2_C" : 20.500}```